### PR TITLE
Fix: Resolve startup error from incompatible type hint syntax

### DIFF
--- a/app/client/encrypt.py
+++ b/app/client/encrypt.py
@@ -1,6 +1,7 @@
 import os, hashlib, requests, brotli, zlib, base64
 from random import randint
 from datetime import datetime, timezone, timedelta
+from typing import Union
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 from dataclasses import dataclass
@@ -79,7 +80,7 @@ def b64(data: bytes, urlsafe: bool) -> str:
     return enc(data).decode("ascii")
 
 
-def build_encrypted_field(iv_hex16: str | None = None, urlsafe_b64: bool = False) -> str:
+def build_encrypted_field(iv_hex16: Union[str, None] = None, urlsafe_b64: bool = False) -> str:
     key = AES_KEY_ASCII.encode("ascii")
     iv_hex = iv_hex16 or random_iv_hex16()
     iv = iv_hex.encode("ascii") 


### PR DESCRIPTION
This commit resolves a startup error that occurred due to the use of Python 3.10+ type hint syntax (`|`) in a project that needs to be compatible with older Python versions. A `TypeError` was raised at import time, preventing the application from running.

This patch replaces all instances of the `|` operator in type hints with `typing.Union` for backward compatibility. The affected files are:
- `app/service/auth.py`
- `app/client/engsel.py`
- `app/client/encrypt.py`

Additionally, a `.gitignore` file has been added to prevent generated files (e.g., `__pycache__`) and sensitive data files (e.g., `api.key`) from being tracked by version control, improving the overall hygiene of the repository.