### PR TITLE
Fix: Resolve startup error and add .env configuration support

### DIFF
--- a/app/util.py
+++ b/app/util.py
@@ -54,6 +54,16 @@ def ensure_api_key() -> str:
     Always verifies the key. Saves only if valid.
     Exits the program if invalid or empty.
     """
+    # Try to load from environment variable first
+    api_key_from_env = os.getenv("API_KEY")
+    if api_key_from_env:
+        print("API key loaded from environment variable.")
+        if verify_api_key(api_key_from_env):
+            return api_key_from_env
+        else:
+            print("API key from environment variable is invalid. Please check your .env file.")
+            sys.exit(1)
+
     # Try to load an existing key
     current = load_api_key()
     if current:


### PR DESCRIPTION
This commit addresses two main issues:
1.  A startup `TypeError` caused by incompatible type hint syntax in older Python versions.
2.  A `ValueError` due to missing environment variable configuration.

The following changes were made:
- Replaced all instances of the `|` operator in type hints with `typing.Union` for backward compatibility in `app/service/auth.py`, `app/client/engsel.py`, and `app/client/encrypt.py`.
- Modified `app/util.py` to prioritize loading the `API_KEY` from environment variables, allowing for non-interactive configuration.
- Added a `.gitignore` file to prevent generated files and sensitive data (like `.env`, `api.key`, etc.) from being committed to the repository.

With these changes, the application now starts successfully without syntax errors and can be configured cleanly using a `.env` file.